### PR TITLE
UnicodeDecodeError on Windows - Update encoding format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+# Custom Update 04-14-21
+Update enconding open(file) to work properly on windows
+
+change all `config_file = open('./config.txt', 'r')` to `config_file = open('./config.txt', 'r', encoding='utf-8')`
+
 # lucyLattes
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2591748.svg)](https://doi.org/10.5281/zenodo.2591748)

--- a/extrafuns.py
+++ b/extrafuns.py
@@ -51,7 +51,7 @@ def fun_idd_unixwind(psys, lscsv, count):
 
 
 def fun_nomeppg():
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     name_ppg = config_file.readlines()[8].split(':')[1]
     name_ppg = name_ppg.rstrip('\n')
     name_ppg = name_ppg.strip(' ')

--- a/grapho.py
+++ b/grapho.py
@@ -24,13 +24,13 @@ def getgrapho():
     # lendo a lista dos IDs e nome dos pesquisadores
     df_idlist = readIdList()
     # df_idlist['ID_LATTES'] = df_idlist['ID_LATTES'].apply(ss)
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     yyi = config_file.readlines()[5].split(':')[1]
     yyi = yyi.rstrip('\n')
     yyi = yyi.strip(' ')
     yyi = float(yyi)
     config_file.close()
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     yyf = config_file.readlines()[6].split(':')[1]
     yyf = yyf.rstrip('\n')
     yyf = yyf.strip(' ')

--- a/index_capes.py
+++ b/index_capes.py
@@ -16,7 +16,7 @@ from extrafuns import *
 
 def capes_indori():
     # nome ppg
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     name_ppg = config_file.readlines()[8].split(':')[1]
     name_ppg = name_ppg.rstrip('\n')
     name_ppg = name_ppg.strip(' ')
@@ -174,7 +174,7 @@ def capes_indprodart():
 
 def capes_indautdis():
     # nome ppg
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     name_ppg = config_file.readlines()[8].split(':')[1]
     name_ppg = name_ppg.rstrip('\n')
     name_ppg = name_ppg.strip(' ')

--- a/lucyLattes.py
+++ b/lucyLattes.py
@@ -68,7 +68,7 @@ getverificacao()
 getgrapho()
 
 # Gerar indicadores qualis ou nao
-config_file = open('./config.txt', 'r')
+config_file = open('./config.txt', 'r', encoding='utf-8')
 run_indcapes = config_file.readlines()[7].split(':')[1]
 run_indcapes = run_indcapes.rstrip('\n')
 run_indcapes = run_indcapes.strip(' ')

--- a/report.py
+++ b/report.py
@@ -17,19 +17,19 @@ style.use('fivethirtyeight')
 
 
 def getrelatorio():
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     yyi = config_file.readlines()[5].split(':')[1]
     yyi = yyi.rstrip('\n')
     yyi = yyi.strip(' ')
     yyi = float(yyi)
     config_file.close()
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     yyf = config_file.readlines()[6].split(':')[1]
     yyf = yyf.rstrip('\n')
     yyf = yyf.strip(' ')
     yyf = float(yyf)
     config_file.close()
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     qualqualis = config_file.readlines()[4].split(':')[1]
     qualqualis = qualqualis.rstrip('\n')
     qualqualis = qualqualis.strip(' ')

--- a/scraperlattes.py
+++ b/scraperlattes.py
@@ -556,7 +556,7 @@ def getperiod(zipname):
                 ls_per_authororder.append(ls_allauthororder)
                 ls_per_orders.append(ls_authororder)
             # Qualis file
-            config_file = open('./config.txt', 'r')
+            config_file = open('./config.txt', 'r', encoding='utf-8')
             qf = config_file.readlines()[4].split(':')[1]
             qf = qf.rstrip('\n')
             qf = qf.strip(' ')

--- a/tidydf.py
+++ b/tidydf.py
@@ -19,13 +19,13 @@ from extrafuns import *
 
 
 def gettidydf():
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     yyi = config_file.readlines()[5].split(':')[1]
     yyi = yyi.rstrip('\n')
     yyi = yyi.strip(' ')
     yyi = float(yyi)
     config_file.close()
-    config_file = open('./config.txt', 'r')
+    config_file = open('./config.txt', 'r', encoding='utf-8')
     yyf = config_file.readlines()[6].split(':')[1]
     yyf = yyf.rstrip('\n')
     yyf = yyf.strip(' ')


### PR DESCRIPTION
While trying it on windows I faced some errors like ``` ''UnicodeDecodeError:` 'charmap' codec can't decode byte 0x9d in position : character maps to <undefined>```

So I discovered that  adding to open , ``` encoding='utf-8'``` could solve the problem on windows and is usually a good thing becouse is the default in Linux and MacOs.